### PR TITLE
Refine database query guard and strengthen history pruning test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Laravel 12 application that embeds a SOHA-style floating assistant backed by L
 - Laravel MCP server (`/mcp/support-chat`) exposing a read-only database query tool and schema resource to AI clients.
 - Database-aware responses: the assistant auto-limits SQL, enforces safe-table rules, returns result tables, and cites the data it used.
 - Configurable OpenAI settings (model, temperature, limits) via `config/chat-agent.php` and environment variables.
-- Session-backed rate limiting to keep the agent responsive in production.
+- Per-actor rate limiting keyed to the authenticated user or request IP to keep the agent responsive in production.
 
 ## Prerequisites
 - PHP 8.3+
@@ -94,7 +94,7 @@ Returns:
   ]
 }
 ```
-Requests are throttled by the `chat-agent` limiter (30 requests/minute per user/ip).
+Requests are throttled by the `chat-agent` limiter (30 requests/minute per authenticated user ID or, for guests, per IP address).
 
 ### GET `/chat-agent/history`
 ```json

--- a/app/Mcp/Tools/DatabaseQueryTool.php
+++ b/app/Mcp/Tools/DatabaseQueryTool.php
@@ -121,30 +121,83 @@ class DatabaseQueryTool extends Tool
 
     protected function guardAgainstRestrictedTables(string $statement): ?Response
     {
-        $lower = strtolower($statement);
         $role = $this->actorContext['role'] ?? 'guest';
-
-        $rules = [
-            ' users' => ['admin'],
-            ' user_' => ['admin'],
-            ' customer' => ['admin', 'sales'],
-            ' sales' => ['admin', 'sales'],
-            ' transaction' => ['admin'],
-            ' salary' => ['admin'],
-        ];
-
-        foreach ($rules as $needle => $allowedRoles) {
-            if (str_contains($lower, $needle)) {
-                if (! in_array($role, $allowedRoles, true)) {
-                    return Response::error('You do not have permission to query protected data sets.');
-                }
-            }
-        }
 
         if ($role === 'guest') {
             return Response::error('Please sign in to run database queries.');
         }
 
+        $tables = $this->extractTableIdentifiers($statement);
+
+        $rules = [
+            'users' => ['admin'],
+            'user_*' => ['admin'],
+            'customer*' => ['admin', 'sales'],
+            'sales*' => ['admin', 'sales'],
+            'transaction*' => ['admin'],
+            'salary*' => ['admin'],
+        ];
+
+        foreach ($tables as $table) {
+            foreach ($rules as $pattern => $allowedRoles) {
+                if (Str::is($pattern, $table) && ! in_array($role, $allowedRoles, true)) {
+                    return Response::error('You do not have permission to query protected data sets.');
+                }
+            }
+        }
+
         return null;
+    }
+
+    /**
+     * Extract table identifiers from a SELECT statement.
+     *
+     * @return list<string>
+     */
+    protected function extractTableIdentifiers(string $statement): array
+    {
+        $tables = [];
+
+        if (! preg_match('/\bfrom\b/i', $statement, $match, PREG_OFFSET_CAPTURE)) {
+            return [];
+        }
+
+        $relevant = substr($statement, $match[0][1]);
+
+        preg_match_all('/(?:\bfrom|\bjoin|,)\s*(?:`[^`]+`|"[^"]+"|\[[^\]]+\]|[a-z0-9_.]+)/i', $relevant, $matches);
+
+        foreach ($matches[0] ?? [] as $segment) {
+            $candidate = preg_replace('/^(?:from|join|,)\s*/i', '', $segment);
+            $identifier = $this->normaliseIdentifier($candidate);
+
+            if ($identifier !== null) {
+                $tables[] = $identifier;
+            }
+        }
+
+        return array_values(array_unique($tables));
+    }
+
+    protected function normaliseIdentifier(string $candidate): ?string
+    {
+        $trimmed = trim($candidate);
+
+        if ($trimmed === '' || str_starts_with($trimmed, '(')) {
+            return null;
+        }
+
+        $trimmed = preg_split('/\s+/', $trimmed)[0] ?? '';
+        $trimmed = trim($trimmed, '`"[]');
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (str_contains($trimmed, '.')) {
+            $segments = explode('.', $trimmed);
+            $trimmed = end($segments) ?: $trimmed;
+        }
+
+        return strtolower($trimmed);
     }
 }

--- a/app/Services/ChatAgentService.php
+++ b/app/Services/ChatAgentService.php
@@ -7,8 +7,8 @@ use App\Mcp\Servers\SupportChatServer;
 use App\Mcp\Tools\DatabaseQueryTool;
 use App\Models\ChatMessage;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Http\Request;
+use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -117,7 +117,7 @@ class ChatAgentService
     protected function buildSystemPrompt(array $actor): string
     {
         try {
-            $schemaSnapshot = (string) $this->schemaResource->handle(new McpRequest())->content();
+            $schemaSnapshot = (string) $this->schemaResource->handle(new McpRequest)->content();
         } catch (Throwable $exception) {
             Log::warning('Failed to build schema snapshot for chat agent', ['exception' => $exception]);
             $schemaSnapshot = 'Schema snapshot unavailable: '.$exception->getMessage();
@@ -314,6 +314,7 @@ class ChatAgentService
         $ids = ChatMessage::forActor($actor)
             ->orderByDesc('created_at')
             ->skip($this->historyLimit)
+            ->take(PHP_INT_MAX)
             ->pluck('id');
 
         if ($ids->isNotEmpty()) {

--- a/tests/Feature/ChatAgentServiceTest.php
+++ b/tests/Feature/ChatAgentServiceTest.php
@@ -6,12 +6,15 @@ use App\Http\Middleware\VerifyCsrfToken;
 use App\Mcp\Tools\DatabaseQueryTool;
 use App\Models\ChatMessage;
 use App\Models\User;
+use App\Services\ChatAgentService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Laravel\Mcp\Request as McpRequest;
 use OpenAI\Laravel\Facades\OpenAI;
 use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Fixtures\Chat\CreateResponseFixture;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -47,19 +50,24 @@ class ChatAgentServiceTest extends TestCase
             ->count(105)
             ->sequence(fn ($sequence) => [
                 'author_role' => $sequence->index % 2 === 0 ? 'user' : 'assistant',
+                'content' => 'Seed message '.$sequence->index,
                 'created_at' => now()->subMinutes(200 - $sequence->index),
                 'updated_at' => now()->subMinutes(200 - $sequence->index),
             ])
             ->forSession($sessionId)
             ->create();
 
-        $response = $this->postJson('/chat-agent/message', [
-            'message' => 'Can you help me?',
-        ]);
+        $sessionStore = Session::driver();
+        $sessionStore->setId($sessionId);
+        $sessionStore->start();
 
-        $response->assertOk()
-            ->assertJsonFragment(['reply' => 'Hello from SOHA'])
-            ->assertJsonCount(100, 'history');
+        $request = Request::create('/chat-agent/message', 'POST');
+        $request->setLaravelSession($sessionStore);
+
+        $response = app(ChatAgentService::class)->reply($request, 'Can you help me?');
+
+        $this->assertSame('Hello from SOHA', $response['reply']);
+        $this->assertCount(100, $response['history']);
 
         $this->assertDatabaseHas('chat_messages', [
             'session_id' => $sessionId,
@@ -71,6 +79,21 @@ class ChatAgentServiceTest extends TestCase
             'session_id' => $sessionId,
             'author_role' => 'assistant',
             'content' => 'Hello from SOHA',
+        ]);
+
+        $this->assertDatabaseMissing('chat_messages', [
+            'session_id' => $sessionId,
+            'content' => 'Seed message 0',
+        ]);
+
+        $this->assertDatabaseMissing('chat_messages', [
+            'session_id' => $sessionId,
+            'content' => 'Seed message 1',
+        ]);
+
+        $this->assertDatabaseHas('chat_messages', [
+            'session_id' => $sessionId,
+            'content' => 'Seed message 7',
         ]);
 
         $this->assertSame(
@@ -147,13 +170,31 @@ class ChatAgentServiceTest extends TestCase
         $this->assertFalse($response->isError());
     }
 
+    #[Test]
+    public function non_restricted_queries_can_reference_user_columns(): void
+    {
+        $tool = app(DatabaseQueryTool::class)->forActor([
+            'role' => 'sales',
+            'user_id' => 2,
+            'session_id' => 'sales-session',
+        ]);
+
+        DB::shouldReceive('select')->once()->andReturn([]);
+
+        $response = $tool->handle(new McpRequest([
+            'statement' => 'SELECT COUNT(*) FROM orders WHERE user_id = 42',
+        ]));
+
+        $this->assertFalse($response->isError());
+    }
+
     protected function fakeChatResponse(string $content): void
     {
         $attributes = CreateResponseFixture::ATTRIBUTES;
         $attributes['choices'][0]['message']['content'] = $content;
 
         OpenAI::fake([
-            CreateResponse::from($attributes),
+            CreateResponse::from($attributes, MetaInformation::from([])),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- tighten the MCP database query guard to analyze table identifiers before enforcing role-based access
- align the README rate-limiting docs with the per-user/IP limiter
- bolster chat history pruning coverage and add a regression test for user_id column queries

## Testing
- php artisan test --filter=ChatAgentServiceTest

------
https://chatgpt.com/codex/tasks/task_e_68d61baf01308320a5c205b2a98b9b54